### PR TITLE
Debug too long key errors

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+One line summary of the issue here.
+
+### Expected behavior
+
+As concisely as possible, describe the expected behavior.
+
+### Actual behavior
+
+As concisely as possible, describe the observed behavior.
+
+### Steps to reproduce the behavior
+
+Please list all relevant steps to reproduce the observed behavior.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Problem
+
+Explain the context and why you're making that change.  What is the
+problem you're trying to solve? In some cases there is not a problem
+and this can be thought of being the motivation for your change.
+
+Solution
+
+Describe the modifications you've done.
+
+Result
+
+What will change as a result of your pull request? Note that sometimes
+this section is unnecessary because it is self-explanatory based on
+the solution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcc
+
+COPY . /usr/src/twemproxy
+WORKDIR /usr/src/twemproxy
+RUN \
+  autoreconf -h && \
+  autoreconf -fvi && \
+  ./configure && \
+  make && \
+  make install
+
+ENTRYPOINT [ "nutcracker" ]

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ https://launchpad.net/~twemproxy/+archive/ubuntu/daily
 + [smitty for twemproxy failover](https://github.com/areina/smitty)
 + [Beholder, a Python agent for twemproxy failover](https://github.com/Serekh/beholder)
 + [chef cookbook](https://supermarket.getchef.com/cookbooks/twemproxy)
-+ [twemsentinel] (https://github.com/yak0/twemsentinel)
++ [twemsentinel](https://github.com/yak0/twemsentinel)
 
 ## Companies using Twemproxy in Production
 + [Twitter](https://twitter.com/)

--- a/src/nc.c
+++ b/src/nc.c
@@ -68,7 +68,7 @@ static struct option long_options[] = {
     { "stats-addr",     required_argument,  NULL,   'a' },
     { "pid-file",       required_argument,  NULL,   'p' },
     { "mbuf-size",      required_argument,  NULL,   'm' },
-    { "mbuf-number",    required_argument,  NULL,   'n' },
+    { "max-reuse",      required_argument,  NULL,   'n' },
     { NULL,             0,                  NULL,    0  }
 };
 
@@ -227,7 +227,7 @@ nc_show_usage(void)
         "  -i, --stats-interval=N : set stats aggregation interval in msec (default: %d msec)" CRLF
         "  -p, --pid-file=S       : set pid file (default: %s)" CRLF
         "  -m, --mbuf-size=N      : set size of mbuf chunk in bytes (default: %d bytes)" CRLF
-        "  -n, --mbuf-number=N    : set maximum number of mbuf chunks (default: 0, means no limit)" CRLF
+        "  -n, --max-reuse=N      : set max number of elements in reuse queues before switching to free (default: 0, means no limit)" CRLF
         "",
         NC_LOG_DEFAULT, NC_LOG_MIN, NC_LOG_MAX,
         NC_LOG_PATH != NULL ? NC_LOG_PATH : "stderr",
@@ -302,7 +302,7 @@ nc_set_default_options(struct instance *nci)
     nci->hostname[NC_MAXHOSTNAMELEN - 1] = '\0';
 
     nci->mbuf_chunk_size = NC_MBUF_SIZE;
-    nci->mbuf_chunk_max = 0;
+    nci->max_reuse_queue = 0;
 
     nci->pid = (pid_t)-1;
     nci->pid_filename = NULL;
@@ -421,13 +421,13 @@ nc_get_options(int argc, char **argv, struct instance *nci)
 
             if ((value != 0 && value < NC_MBUF_MIN_NUM) || 
                  value > NC_MBUF_MAX_NUM) {
-                log_stderr("nutcracker: maximum number of mbuf chunks must be "
+                log_stderr("nutcracker: maximum elements in reuse queues must be "
                            "zero or between %zu and %zu", NC_MBUF_MIN_NUM, 
                                NC_MBUF_MAX_NUM);
                 return NC_ERROR;
             }
 
-            nci->mbuf_chunk_max = (size_t)value;
+            nci->max_reuse_queue = (size_t)value;
             break;
 
         case '?':

--- a/src/nc_connection.h
+++ b/src/nc_connection.h
@@ -99,7 +99,7 @@ struct conn *conn_get_proxy(void *owner);
 void conn_put(struct conn *conn);
 ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
 ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);
-void conn_init(void);
+void conn_init(struct instance *nci);
 void conn_deinit(void);
 uint32_t conn_ncurr_conn(void);
 uint64_t conn_ntotal_conn(void);

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -161,8 +161,8 @@ core_start(struct instance *nci)
     struct context *ctx;
 
     mbuf_init(nci);
-    msg_init();
-    conn_init();
+    msg_init(nci);
+    conn_init(nci);
 
     ctx = core_ctx_create(nci);
     if (ctx != NULL) {

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -298,7 +298,7 @@ core_timeout(struct context *ctx)
         }
 
         log_warn("[TIMEOUT]: req %"PRIu64" on s %d timedout", msg->id, conn->sd);
-        msg_dump(msg, LOG_WARN);
+        msg_dump(msg, LOG_WARN, MSG_DUMP_TEXT);
 
         msg_tmo_delete(msg);
         conn->err = ETIMEDOUT;

--- a/src/nc_core.c
+++ b/src/nc_core.c
@@ -297,7 +297,8 @@ core_timeout(struct context *ctx)
             return;
         }
 
-        log_debug(LOG_INFO, "req %"PRIu64" on s %d timedout", msg->id, conn->sd);
+        log_warn("[TIMEOUT]: req %"PRIu64" on s %d timedout", msg->id, conn->sd);
+        msg_dump(msg, LOG_WARN);
 
         msg_tmo_delete(msg);
         conn->err = ETIMEDOUT;

--- a/src/nc_core.h
+++ b/src/nc_core.h
@@ -144,7 +144,7 @@ struct instance {
     char            *stats_addr;                 /* stats monitoring addr */
     char            hostname[NC_MAXHOSTNAMELEN]; /* hostname */
     size_t          mbuf_chunk_size;             /* mbuf chunk size */
-    size_t          mbuf_chunk_max;              /* maximum number of mbuf chunks */
+    size_t          max_reuse_queue;              /* maximum of elements in reuse queues */
     pid_t           pid;                         /* process id */
     char            *pid_filename;               /* pid filename */
     unsigned        pidfile:1;                   /* pid file created? */

--- a/src/nc_mbuf.c
+++ b/src/nc_mbuf.c
@@ -273,7 +273,7 @@ mbuf_init(struct instance *nci)
 
     mbuf_chunk_size = nci->mbuf_chunk_size;
     mbuf_offset = mbuf_chunk_size - MBUF_HSIZE;
-    mbuf_chunk_max = nci->mbuf_chunk_max;
+    mbuf_chunk_max = nci->max_reuse_queue;
 
     log_debug(LOG_DEBUG, "mbuf hsize %d chunk size %zu offset %zu length %zu",
               MBUF_HSIZE, mbuf_chunk_size, mbuf_offset, mbuf_offset);

--- a/src/nc_mbuf.h
+++ b/src/nc_mbuf.h
@@ -38,7 +38,7 @@ STAILQ_HEAD(mhdr, mbuf);
 #define MBUF_MAX_SIZE   16777216
 #define MBUF_SIZE       16384
 #define MBUF_HSIZE      sizeof(struct mbuf)
-#define MBUF_MIN_NUM    524288
+#define MBUF_MIN_NUM    1
 #define MBUF_MAX_NUM    134217728
 
 static inline bool

--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -400,7 +400,7 @@ msg_put(struct msg *msg)
 }
 
 void
-msg_dump(struct msg *msg, int level)
+msg_dump(struct msg *msg, int level, msg_dump_format_t which_format)
 {
     struct mbuf *mbuf;
 
@@ -412,6 +412,10 @@ msg_dump(struct msg *msg, int level)
          "error %d (err %d)", msg->id, msg->request, msg->mlen, msg->type,
          msg->done, msg->error, msg->err);
 
+    if (which_format == MSG_DUMP_TEXT) {
+        loga("---MSG DUMP BEGIN---");
+    }
+
     STAILQ_FOREACH(mbuf, &msg->mhdr, next) {
         uint8_t *p, *q;
         long int len;
@@ -420,7 +424,20 @@ msg_dump(struct msg *msg, int level)
         q = mbuf->last;
         len = q - p;
 
-        loga_hexdump(p, len, "mbuf [%p] with %ld bytes of data", p, len);
+        switch (which_format) {
+            case MSG_DUMP_HEXA:
+                loga_hexdump(p, len, "mbuf [%p] with %ld bytes of data", p, len);
+                break;
+            case MSG_DUMP_TEXT:
+                loga("%.*s", len, p);
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (which_format == MSG_DUMP_TEXT) {
+        loga("---MSG DUMP END---");
     }
 }
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -278,7 +278,7 @@ struct msg *msg_tmo_min(void);
 void msg_tmo_insert(struct msg *msg, struct conn *conn);
 void msg_tmo_delete(struct msg *msg);
 
-void msg_init(void);
+void msg_init(struct instance *nci);
 void msg_deinit(void);
 struct string *msg_type_string(msg_type_t type);
 struct msg *msg_get(struct conn *conn, bool request, bool redis);

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -272,6 +272,11 @@ struct msg {
     unsigned             redis:1;         /* redis? */
 };
 
+typedef enum msg_dump_format {
+    MSG_DUMP_HEXA,
+    MSG_DUMP_TEXT,
+} msg_dump_format_t;
+
 TAILQ_HEAD(msg_tqh, msg);
 
 struct msg *msg_tmo_min(void);
@@ -284,7 +289,7 @@ struct string *msg_type_string(msg_type_t type);
 struct msg *msg_get(struct conn *conn, bool request, bool redis);
 void msg_put(struct msg *msg);
 struct msg *msg_get_error(bool redis, err_t err);
-void msg_dump(struct msg *msg, int level);
+void msg_dump(struct msg *msg, int level, msg_dump_format_t);
 bool msg_empty(struct msg *msg);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -235,6 +235,7 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_SUNIONSTORE:
     case MSG_REQ_REDIS_SRANDMEMBER:
     case MSG_REQ_REDIS_SSCAN:
+    case MSG_REQ_REDIS_SPOP:
 
     case MSG_REQ_REDIS_PFADD:
     case MSG_REQ_REDIS_PFMERGE:
@@ -273,7 +274,6 @@ redis_argx(struct msg *r)
     switch (r->type) {
     case MSG_REQ_REDIS_MGET:
     case MSG_REQ_REDIS_DEL:
-    case MSG_REQ_REDIS_SPOP:
         return true;
 
     default:

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -85,7 +85,6 @@ redis_arg0(struct msg *r)
 
     case MSG_REQ_REDIS_SCARD:
     case MSG_REQ_REDIS_SMEMBERS:
-    case MSG_REQ_REDIS_SPOP:
 
     case MSG_REQ_REDIS_ZCARD:
     case MSG_REQ_REDIS_PFCOUNT:
@@ -274,6 +273,7 @@ redis_argx(struct msg *r)
     switch (r->type) {
     case MSG_REQ_REDIS_MGET:
     case MSG_REQ_REDIS_DEL:
+    case MSG_REQ_REDIS_SPOP:
         return true;
 
     default:

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -1173,10 +1173,12 @@ redis_parse_req(struct msg *r)
                 r->rlen = r->rlen * 10 + (uint32_t)(ch - '0');
             } else if (ch == CR) {
                 if (r->rlen >= mbuf_data_size()) {
-                    log_error("parsed bad req %"PRIu64" of type %d with key "
+                    struct string *r_type = msg_type_string(r->type);
+                    log_error("parsed bad req %"PRIu64" of type %.*s with key "
                               "length %d that greater than or equal to maximum"
-                              " redis key length of %d", r->id, r->type,
+                              " redis key length of %d", r->id, r_type->len, r_type->data,
                               r->rlen, mbuf_data_size());
+                    msg_dump(r, LOG_ERR, MSG_DUMP_TEXT);
                     goto error;
                 }
                 if (r->rnarg == 0) {


### PR DESCRIPTION
Dump message and show actual command when a command with a tool long key causes an error